### PR TITLE
add get_config in Sine to avoid model saving problem

### DIFF
--- a/tf_siren/siren.py
+++ b/tf_siren/siren.py
@@ -55,6 +55,11 @@ class Sine(tf.keras.layers.Layer):
 
     def call(self, inputs, **kwargs):
         return tf.sin(self.w0 * inputs)
+    
+    def get_config(self):
+        config = {'w0': self.w0}
+        base_config = super(Sine, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
 
 
 class SinusodialRepresentationDense(tf.keras.layers.Dense):


### PR DESCRIPTION
I added get_config in tf_siren/siren.py (class Sine(tf.keras.layers.Layer)) to avoid below problem when saving model and weighting:
NotImplementedError: Layer Sine has arguments in `__init__` and therefore must override `get_config`.
