### PR TITLE
edit __int__ in SIRENInitializer to avoid model loading problem

### DIFF
--- a/tf_siren/siren.py
+++ b/tf_siren/siren.py
@@ -26,7 +26,7 @@ class SIRENFirstLayerInitializer(tf.keras.initializers.Initializer):
 
 class SIRENInitializer(tf.keras.initializers.VarianceScaling):
 
-    def __init__(self, w0: float = 1.0, c: float = 6.0, seed: int = None):
+    def __init__(self, scale = 1.0, w0: float = 1.0, c: float = 6.0, seed: int = None, mode='fan_in', distribution='uniform'):
         # Uniform variance scaler multiplies by 3.0 for limits, so scale down here to compensate
         self.w0 = w0
         self.c = c


### PR DESCRIPTION
Sorry to bother again, there were some error occur (TypeError: __init__() got an unexpected keyword argument 'scale') when I loaded the model based on tf_siren. Now tf_siren can work without error on my machine after modified.