### PR TITLE
fix crash when saving model with Sine layer using TensorFlow 2.2.0

### DIFF
--- a/tf_siren/siren.py
+++ b/tf_siren/siren.py
@@ -53,7 +53,7 @@ class Sine(tf.keras.layers.Layer):
         super(Sine, self).__init__(**kwargs)
         self.w0 = w0
 
-    def call(self, inputs, **kwargs):
+    def call(self, inputs):
         return tf.sin(self.w0 * inputs)
     
     def get_config(self):


### PR DESCRIPTION
Thanks for the cool library! In the latest version of my [mathy](https://mathy.ai) library I'm using SRD layers from your package, and TensorFlow 2.2 has trouble saving them.

Specifically, the `SinusodialRepresentationDense` layer uses `Sine` which has an unused `**kwargs` argument that causes my model to crash on save. 

The related TensorFlow issue is: https://github.com/tensorflow/tensorflow/issues/38384

This commit removes the unused kwargs var so that models like mine can serialize with TF 2.2